### PR TITLE
Use visible height to decide where to position the info view

### DIFF
--- a/materialintro/src/main/java/co/mobiwise/materialintro/view/MaterialIntroView.java
+++ b/materialintro/src/main/java/co/mobiwise/materialintro/view/MaterialIntroView.java
@@ -472,7 +472,10 @@ public class MaterialIntroView extends RelativeLayout {
                         ViewGroup.LayoutParams.MATCH_PARENT,
                         ViewGroup.LayoutParams.FILL_PARENT);
 
-                if (targetShape.getPoint().y < height / 2) {
+                android.graphics.Rect r = new android.graphics.Rect();
+                targetView.getView().getWindowVisibleDisplayFrame(r);
+
+                if (targetShape.getPoint().y < r.top + r.height() / 2) {
                     ((RelativeLayout) infoView).setGravity(Gravity.TOP);
                     infoDialogParams.setMargins(
                             0,


### PR DESCRIPTION
Previously `height` is basically the device height (since the view takes up the size of the decor view). If there is a keyboard open, the visible display frame is smaller, so we should use that to decide where to position the info view (above or below).